### PR TITLE
feat: Add configurable screenshot interval with config file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ macOS上で動作する作業ログ自動生成ツール。スクリーンショ
 ## 特徴
 
 - **完全ローカル処理**: スクリーンショット・OCR処理はすべてローカルで完結（外部APIを使わない）
-- **自動記録**: 1分間隔でバックグラウンド動作
+- **自動記録**: 設定可能な間隔（デフォルト5分）でバックグラウンド動作
 - **日本語・英語対応**: macOS Vision Frameworkによる高精度OCR
 - **AI連携前提**: 蓄積されたログをAIに渡して作業時間をまとめられる
 
@@ -35,17 +35,25 @@ pip install -r requirements.txt
 ### 起動
 
 ```bash
-# 起動スクリプトを使用
-./scripts/start.sh
+# 起動スクリプトを使用（デフォルト: 5分間隔）
+./scripts/start-background.sh
+
+# キャプチャ間隔を指定して起動（秒単位）
+./scripts/start-background.sh --interval 60    # 1分間隔
+./scripts/start-background.sh --interval 300   # 5分間隔
+./scripts/start-background.sh --interval 600   # 10分間隔
 
 # または直接実行
 python -m screenlog.main
 
 # キャプチャ間隔を指定（秒）
-python -m screenlog.main -i 30
+python -m screenlog.main -i 60
 
 # 1回だけキャプチャして終了
 python -m screenlog.main --once
+
+# 設定をファイルに保存（次回以降のデフォルトになる）
+python -m screenlog.main -i 300 --save-config
 ```
 
 ### 停止

--- a/screenlog/config.py
+++ b/screenlog/config.py
@@ -1,0 +1,75 @@
+"""ScreenLog - 設定管理"""
+
+import json
+from pathlib import Path
+
+# デフォルト設定
+DEFAULT_INTERVAL = 300  # 5分
+DEFAULT_RETENTION_DAYS = 30
+MIN_INTERVAL = 10  # 最小間隔（秒）
+
+CONFIG_DIR = Path.home() / "Library" / "Application Support" / "ScreenLog"
+CONFIG_FILE = CONFIG_DIR / "config.json"
+
+
+def get_config() -> dict:
+    """
+    設定ファイルを読み込む。存在しない場合はデフォルト値を返す。
+
+    Returns:
+        dict: 設定辞書
+    """
+    defaults = {
+        "interval": DEFAULT_INTERVAL,
+        "retention_days": DEFAULT_RETENTION_DAYS,
+    }
+
+    if CONFIG_FILE.exists():
+        try:
+            with open(CONFIG_FILE, "r", encoding="utf-8") as f:
+                user_config = json.load(f)
+            defaults.update(user_config)
+        except (json.JSONDecodeError, OSError) as e:
+            print(f"Warning: Could not read config file {CONFIG_FILE}: {e}")
+
+    return defaults
+
+
+def save_config(config: dict) -> bool:
+    """
+    設定をファイルに保存する。
+
+    Args:
+        config: 保存する設定辞書
+
+    Returns:
+        bool: 保存成功ならTrue
+    """
+    try:
+        CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+            json.dump(config, f, indent=2, ensure_ascii=False)
+        return True
+    except OSError as e:
+        print(f"Warning: Could not save config file {CONFIG_FILE}: {e}")
+        return False
+
+
+def validate_interval(interval: int) -> int:
+    """
+    間隔値をバリデーションする。
+
+    Args:
+        interval: キャプチャ間隔（秒）
+
+    Returns:
+        int: バリデーション済みの間隔値
+
+    Raises:
+        ValueError: 間隔が不正な場合
+    """
+    if interval < MIN_INTERVAL:
+        raise ValueError(
+            f"キャプチャ間隔は{MIN_INTERVAL}秒以上を指定してください（指定値: {interval}秒）"
+        )
+    return interval

--- a/scripts/start-background.sh
+++ b/scripts/start-background.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 # ScreenLog バックグラウンド起動スクリプト
 # ターミナルの画面収録権限を利用して実行
+#
+# Usage:
+#   ./start-background.sh              # デフォルト設定で起動
+#   ./start-background.sh --interval 60  # 60秒間隔で起動
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
@@ -25,7 +29,7 @@ mkdir -p "$HOME/ScreenLog/logs"
 source venv/bin/activate
 
 echo "Starting ScreenLog in background..."
-nohup python -m screenlog.main > "$LOG_FILE" 2>&1 &
+nohup python -m screenlog.main "$@" > "$LOG_FILE" 2>&1 &
 PID=$!
 echo $PID > "$PID_FILE"
 


### PR DESCRIPTION
## Summary
- 設定ファイル (`config.json`) によるキャプチャ間隔の永続化をサポート
- `--save-config` フラグで現在のオプションを保存可能に
- 間隔のバリデーション（最小10秒）を追加
- `start-background.sh` がCLI引数をそのまま転送するように変更

## Test plan
- [ ] `python -m screenlog.main -i 60` で1分間隔で動作することを確認
- [ ] `python -m screenlog.main -i 5` でバリデーションエラーになることを確認
- [ ] `python -m screenlog.main -i 300 --save-config` で設定ファイルが作成されることを確認
- [ ] 設定ファイル保存後、引数なしで起動して保存した間隔が使われることを確認
- [ ] `./scripts/start-background.sh --interval 120` でバックグラウンド起動できることを確認

Closes #4